### PR TITLE
Add profile for local gepardec-sso

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -161,6 +161,12 @@ mp:
       employees:
         notification: true
 
+## local-sso profile
+"%local-sso":
+  mega:
+    oauth:
+      issuer: "http://localhost:8180/realms/gepardec"
+
 ## TEST Properties
 "%test":
   quarkus:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -162,7 +162,7 @@ mp:
         notification: true
 
 ## local-sso profile
-"%local-sso":
+"%localsso":
   mega:
     oauth:
       issuer: "http://localhost:8180/realms/gepardec"


### PR DESCRIPTION
Neues Profil hinzugefügt, um parallel eine Gepardec-SSO Instanz laufen zu lassen, über den die Authentifizierung durchgeführt werden kann.