### PR TITLE
[Gepardec/mega#737] remove vacationDaybalance 

### DIFF
--- a/src/main/java/com/gepardec/mega/personio/employees/PersonioEmployeeDto.java
+++ b/src/main/java/com/gepardec/mega/personio/employees/PersonioEmployeeDto.java
@@ -13,7 +13,6 @@ public record PersonioEmployeeDto(
         Attribute<String> lastName,
         Attribute<String> email,
         Attribute<List<TimeOffType>> absenceEntitlement,
-        Attribute<Double> vacationDayBalance,
         Attribute<String> personalnummer,
         Attribute<String> guildLead,
         Attribute<String> internalProjectLead
@@ -27,7 +26,6 @@ public record PersonioEmployeeDto(
                 builder.lastName,
                 builder.email,
                 builder.absenceEntitlement,
-                builder.vacationDayBalance,
                 builder.personalnummer,
                 builder.guildLead,
                 builder.internalProjectLead
@@ -52,9 +50,6 @@ public record PersonioEmployeeDto(
 
         @JsonProperty("absence_entitlement")
         private Attribute<List<TimeOffType>> absenceEntitlement;
-
-        @JsonProperty("vacation_day_balance")
-        private Attribute<Double> vacationDayBalance;
 
         @JsonProperty("dynamic_393528")
         private Attribute<String> personalnummer;
@@ -87,11 +82,6 @@ public record PersonioEmployeeDto(
 
         public Builder absenceEntitlement(Attribute<List<TimeOffType>> absenceEntitlement) {
             this.absenceEntitlement = absenceEntitlement;
-            return this;
-        }
-
-        public Builder vacationDayBalance(Attribute<Double> vacationDayBalance) {
-            this.vacationDayBalance = vacationDayBalance;
             return this;
         }
 

--- a/src/main/java/com/gepardec/mega/rest/mapper/PersonioEmployeeMapper.java
+++ b/src/main/java/com/gepardec/mega/rest/mapper/PersonioEmployeeMapper.java
@@ -15,7 +15,6 @@ public class PersonioEmployeeMapper implements DtoMapper<PersonioEmployee, Perso
 
         return PersonioEmployeeDto.builder()
                 .email(Attribute.ofValue(domain.getEmail()))
-                .vacationDayBalance(Attribute.ofValue(domain.getVacationDayBalance()))
                 .guildLead(Attribute.ofValue(domain.getGuildLead()))
                 .internalProjectLead(Attribute.ofValue(domain.getInternalProjectLead()))
                 .build();
@@ -27,11 +26,11 @@ public class PersonioEmployeeMapper implements DtoMapper<PersonioEmployee, Perso
             return null;
         }
 
+        //TODO: If vacation day balance is queried from Personio, it should be added here
         return PersonioEmployee.builder()
                 .email(dto.email() == null ?
                         null : dto.email().getValue())
-                .vacationDayBalance(dto.vacationDayBalance() == null ?
-                        null : dto.vacationDayBalance().getValue())
+                .vacationDayBalance(null)
                 .guildLead(dto.guildLead() == null ?
                         null : dto.guildLead().getValue())
                 .internalProjectLead(dto.internalProjectLead() == null ?

--- a/src/test/java/com/gepardec/mega/personio/employees/PersonioEmployeesServiceImplTest.java
+++ b/src/test/java/com/gepardec/mega/personio/employees/PersonioEmployeesServiceImplTest.java
@@ -50,7 +50,6 @@ class PersonioEmployeesServiceImplTest {
         //THEN
         assertThat(result).isNotEmpty();
         PersonioEmployee personioEmployee = result.get();
-        assertThat(personioEmployee.getVacationDayBalance()).isEqualTo(10d);
         assertThat(personioEmployee.getGuildLead()).isEqualTo("guildLead");
         assertThat(personioEmployee.getInternalProjectLead()).isEqualTo("internalProjectLead");
     }
@@ -112,7 +111,6 @@ class PersonioEmployeesServiceImplTest {
 
     private static PersonioEmployeeDto createPersonioEmployee() {
         return PersonioEmployeeDto.builder()
-                .vacationDayBalance(Attribute.ofValue(10d))
                 .guildLead(Attribute.ofValue("guildLead"))
                 .internalProjectLead(Attribute.ofValue("internalProjectLead"))
                 .build();

--- a/src/test/java/com/gepardec/mega/rest/mapper/PersonioEmployeeMapperTest.java
+++ b/src/test/java/com/gepardec/mega/rest/mapper/PersonioEmployeeMapperTest.java
@@ -24,14 +24,13 @@ public class PersonioEmployeeMapperTest {
     void setUp() {
         domain = PersonioEmployee.builder()
                 .email("testuser@testmail.com")
-                .vacationDayBalance(25.35)
+                .vacationDayBalance(null)
                 .guildLead("TestGuildLead")
                 .internalProjectLead("TestLead")
                 .build();
 
         dto = PersonioEmployeeDto.builder()
                 .email(Attribute.ofValue("testuser@testmail.com"))
-                .vacationDayBalance(Attribute.ofValue(25.35))
                 .guildLead(Attribute.ofValue("TestGuildLead"))
                 .internalProjectLead(Attribute.ofValue("TestLead"))
                 .build();


### PR DESCRIPTION
remove vacationDaybalance from Dto and default the corresponding attribute in the Domain Model to null until retrieval of the VacationDayBalance from another endpoint gets implemented




**Prerequisites: Always create two feature branches (frontend + backend) even if your feature only affects one of them**

**DEV:**
> Development
- [ ] Acceptance tests by dev [OpenShift feature environment]
  - [ ] Moved to "Ready for review"

> Review
- [ ] Pull-request reviewed + approved (including Code Coverage) by reviewer [GitHub]
- [ ] Inform dev after review through MEGA-PR (by reviewer) [Chat Space]
- [ ] Version upgrade by dev [GitHub Issue Milestone + maven revision]
- [ ] Merge to main by dev [GitHub]
  - [ ]  Re-add SNAPSHOT to version and push on main [maven revision]
  - [ ]  Make sure all feature branches are deleted [frontend + backend]
  - [ ]  Moved to "Ready for deployment"

> Deployment
- [ ] Integration and Unit tests on main environment passed [Workflow]
- [ ] Deployed to the test environment [GitOps Workflow triggered]
  - [ ] Moved to "Ready for testing"

**PO:**
> Testing
- [ ] Acceptance tests on the test enviroment passed
- [ ] Inspected and approved
  - [ ] Moved to "Ready for release"
