### PR TITLE
Autoupdate Quarkus 3.34.1 -> 3.35.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.8.1</maven.version>
 
-        <quarkus.version>3.34.1</quarkus.version>
+        <quarkus.version>3.35.3</quarkus.version>
 
         <ws.rt.version>4.0.4</ws.rt.version>
         <focus-shift.version>2.4.0</focus-shift.version>


### PR DESCRIPTION
This PR was created automatically from Renovate PR `renovate/quarkus_3.34.1_3.35.3`.

Dependency: `quarkus`
Current version: `3.34.1`
New version: `3.35.3`

It applies the Quarkus update directly on top of `feature/base-auto-update`.