### PR TITLE
Autoupdate Quarkus 3.34.1 -> 3.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.8.1</maven.version>
 
-        <quarkus.version>3.34.1</quarkus.version>
+        <quarkus.version>3.36.0</quarkus.version>
 
         <ws.rt.version>4.0.4</ws.rt.version>
         <focus-shift.version>2.10.1</focus-shift.version>

--- a/src/test/java/com/gepardec/mega/helper/ResourceFileService.java
+++ b/src/test/java/com/gepardec/mega/helper/ResourceFileService.java
@@ -63,13 +63,12 @@ public class ResourceFileService {
 
     private File getFileOfResourcesPath(String path) {
         try {
-            URL resource = getClass().getResource("/");
+            URL resource = getClass().getResource(path);
             if (resource == null) {
                 throw new IOException("Resource not found: " + path);
             }
             String resourcesPath = resource.getPath();
-            String absPath = resourcesPath + path;
-            return new File(absPath);
+            return new File(resourcesPath);
         } catch (Exception e) {
             throw new RuntimeException("Error reading resource Path for test resources", e);
         }


### PR DESCRIPTION
This PR was created automatically from Renovate PR `renovate/quarkus_3.34.1_3.36.0`.

Dependency: `quarkus`
Current version: `3.34.1`
New version: `3.36.0`

It applies the Quarkus update directly on top of `feature/base-auto-update`.