### PR TITLE
Autoupdate Quarkus 3.36.0 -> 3.37.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.8.1</maven.version>
 
-        <quarkus.version>3.36.1</quarkus.version>
+        <quarkus.version>3.37.0</quarkus.version>
 
         <ws.rt.version>4.0.5</ws.rt.version>
         <focus-shift.version>2.12.0</focus-shift.version>


### PR DESCRIPTION
This PR was created automatically from Renovate PR `renovate/quarkus_3.36.0_3.37.0`.

Dependency: `quarkus`
Current version: `3.36.0`
New version: `3.37.0`

It applies the Quarkus update directly on top of `feature/base-auto-update`.